### PR TITLE
upgrade to python3

### DIFF
--- a/bin/tcl_cli.py
+++ b/bin/tcl_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import logging
 import readline
@@ -21,7 +21,7 @@ def main():
         logging.getLogger('pyixia.tclproto').setLevel(logging.DEBUG)
 
     if len(args) < 1:
-        print parser.format_help()
+        print(parser.format_help())
         sys.exit(1)
 
     host = args[0]
@@ -29,24 +29,24 @@ def main():
     tcl = TclClient(host)
     tcl.connect()
     if options.autoconnect:
-        print tcl.call('ixConnectToChassis %s', host)[1]
+        print(tcl.call('ixConnectToChassis %s', host)[1])
 
-    print "Enter command to send. Quit with 'q'."
+    print("Enter command to send. Quit with 'q'.")
     try:
         while True:
-            cmd = raw_input('=> ')
+            cmd = input('=> ')
             if cmd == 'q':
                 break
             if len(cmd) > 0:
                 try:
                     (res, io) = tcl.call(cmd)
-                    print res
+                    print(res)
                     if io is not None:
-                        print io
-                except TclError, e:
-                    print 'ERROR: %s' % e.result
+                        print("output: %s" % io)
+                except TclError as e:
+                    print('ERROR: %s' % e.result)
     except EOFError:
-        print 'exitting..'
+        print('exitting..')
 
 if __name__ == '__main__':
     main()

--- a/examples/discover-chassis.py
+++ b/examples/discover-chassis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import sys
@@ -21,18 +21,18 @@ def main():
     if len(sys.argv) == 2 and sys.argv[1] == '-d':
         logging.getLogger().setLevel(logging.DEBUG)
 
-    i = Ixia('ixia01')
+    i = Ixia('ixia')
     i.connect()
     i.discover()
 
-    print '%8s | %8s | %s' % ('Port', 'Owner', 'Link State')
-    print '---------+----------+-----------------'
+    print('%8s | %8s | %s' % ('Port', 'Owner', 'Link State'))
+    print('---------+----------+-----------------')
     for card in i.chassis.cards:
         if card is None:
             continue
         for port in card.ports:
-            print '%8s | %8s | %s' % (port, port.owner,
-                    link_state_str(port.link_state))
+            print('%8s | %8s | %s' % (port, port.owner,
+                    link_state_str(port.link_state)))
 
     i.disconnect()
 

--- a/examples/port-groups-take-ownership.py
+++ b/examples/port-groups-take-ownership.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import sys

--- a/pyixia/__init__.py
+++ b/pyixia/__init__.py
@@ -15,13 +15,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import logging
-from tclproto import TclClient
-from ixapi import _MetaIxTclApi, TclMember, FLAG_RDONLY
-from ixapi import IxTclHalApi, IxTclHalError
+from .tclproto import TclClient
+from .ixapi import _MetaIxTclApi, TclMember, FLAG_RDONLY
+from .ixapi import IxTclHalApi, IxTclHalError
 
 log = logging.getLogger(__name__)
 
-class PortGroup(object):
+class PortGroup(metaclass=_MetaIxTclApi):
     START_TRANSMIT = 7
     STOP_TRANSMIT = 8
     START_CAPTURE = 9
@@ -35,7 +35,6 @@ class PortGroup(object):
     CLEAR_OWNERSHIP = 42
     CLEAR_OWNERSHIP_FORCED = 43
 
-    __metaclass__ = _MetaIxTclApi
     __tcl_command__ = 'portGroup'
     __tcl_members__ = [
             TclMember('lastTimeStamp', type=int, flags=FLAG_RDONLY),
@@ -108,9 +107,8 @@ class PortGroup(object):
             self._set_command(self.CLEAR_OWNERSHIP_FORCED)
 
 
-class Statistics(object):
+class Statistics(metaclass=_MetaIxTclApi):
     """Per port statistics."""
-    __metaclass__ = _MetaIxTclApi
     __tcl_command__ = 'stat'
     __tcl_members__ = [
             TclMember('bytesReceived', type=int, flags=FLAG_RDONLY),
@@ -129,8 +127,7 @@ class Statistics(object):
                 member.name, *self.port._port_id())
 
 
-class Port(object):
-    __metaclass__ = _MetaIxTclApi
+class Port(metaclass=_MetaIxTclApi):
     __tcl_command__ = 'port'
     __tcl_members__ = [
             TclMember('name'),
@@ -177,8 +174,7 @@ class Port(object):
     def __str__(self):
         return '%d/%d/%d' % self._port_id()
 
-class Card(object):
-    __metaclass__ = _MetaIxTclApi
+class Card(metaclass=_MetaIxTclApi):
     __tcl_command__ = 'card'
     __tcl_members__ = [
             TclMember('cardOperationMode', type=int, flags=FLAG_RDONLY),
@@ -209,7 +205,7 @@ class Card(object):
         self._api.call_rc('card set %d %d', *self._card_id())
 
     def discover(self):
-        for pid in xrange(self.port_count):
+        for pid in range(self.port_count):
             pid += 1 # one-based
             port = Port(self._api, self, pid)
             log.info('Adding port %s', port)
@@ -222,8 +218,7 @@ class Card(object):
         return '%d/%d' % self._card_id()
 
 
-class Chassis(object):
-    __metaclass__ = _MetaIxTclApi
+class Chassis(metaclass=_MetaIxTclApi):
     __tcl_command__ = 'chassis'
     __tcl_members__ = [
             TclMember('baseIpAddress'),
@@ -289,7 +284,7 @@ class Chassis(object):
 
     def discover(self):
         log.info('Discover chassis %d (%s)', self.id, self.type_name)
-        for cid in xrange(self.max_card_count):
+        for cid in range(self.max_card_count):
             # unfortunately there is no config option which cards are used. So
             # we have to iterate over all possible card ids and check if we are
             # able to get a handle.
@@ -303,8 +298,7 @@ class Chassis(object):
                 # keep in sync with card ids
                 self.cards.append(None)
 
-class Session(object):
-    __metaclass__ = _MetaIxTclApi
+class Session(metaclass=_MetaIxTclApi):
     __tcl_command__ = 'session'
     __tcl_members__ = [
             TclMember('userName', flags=FLAG_RDONLY),
@@ -327,7 +321,7 @@ class Session(object):
         self._api.call_rc('session logout')
 
 
-class Ixia(object):
+class Ixia:
     """This class supports only one chassis atm."""
     def __init__(self, host):
         self.host = host

--- a/pyixia/ixapi.py
+++ b/pyixia/ixapi.py
@@ -79,7 +79,7 @@ def translate_ix_member_name(name):
     return ''.join(_new_name)
 
 
-class TclMember(object):
+class TclMember:
     def __init__(self, name, type=str, attrname=None, flags=0, doc=None):
         self.name = name
         self.type = type
@@ -97,7 +97,7 @@ class IxTclHalError(Exception):
         return '%s: %s' % (self.__class__.__name__, self.rc)
 
 
-class IxTclHalApi(object):
+class IxTclHalApi:
     def __init__(self, tcl_handler):
         self._tcl_handler = tcl_handler
 

--- a/pyixia/tclproto.py
+++ b/pyixia/tclproto.py
@@ -44,16 +44,15 @@ class TclClient:
 
         string += '\r\n'
         data = string % args
-        log.debug('sending %s (%s)', data.rstrip(), data.encode('hex'))
+        log.debug('sending %s (%s)', data.rstrip(), data.encode('utf-8').hex())
         self.fd.send(data)
 
         # reply format is
         #  [<io output>\r]<result><tcl return code>\r\n
         # where tcl_return code is exactly one byte
         data = self.fd.recv(self.buffersize)
-        log.debug('received %s (%s)', data.rstrip(), data.encode('hex'))
-        #print 'data=(%s) (%s)' % (data, data.encode('hex'))
-        assert data[-2:] == '\r\n'
+        log.debug('received %s (%s)', data.rstrip(), data.hex())
+        assert data[-2:] == b'\r\n'
 
         tcl_result = int(data[-3])
 


### PR DESCRIPTION
Just python3 is supported. python2 is gone for good.

Signed-off-by: Michael Walle <michael.walle@kontron.com>