### PR TITLE
tclproto: introduce new TclSocketClient

### DIFF
--- a/bin/tcl_cli.py
+++ b/bin/tcl_cli.py
@@ -4,7 +4,7 @@ import logging
 import readline
 from optparse import OptionParser
 
-from pyixia.tclproto import TclClient, TclError
+from pyixia.tclproto import TclSocketClient, TclError
 
 def main():
     usage = 'usage: %prog [options] <host>'
@@ -26,7 +26,7 @@ def main():
 
     host = args[0]
 
-    tcl = TclClient(host)
+    tcl = TclSocketClient(host)
     tcl.connect()
     if options.autoconnect:
         print(tcl.call('ixConnectToChassis %s', host)[1])

--- a/pyixia/__init__.py
+++ b/pyixia/__init__.py
@@ -15,7 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import logging
-from .tclproto import TclClient
+from .tclproto import TclSocketClient
 from .ixapi import _MetaIxTclApi, TclMember, FLAG_RDONLY
 from .ixapi import IxTclHalApi, IxTclHalError
 
@@ -325,7 +325,7 @@ class Ixia:
     """This class supports only one chassis atm."""
     def __init__(self, host):
         self.host = host
-        self._tcl = TclClient(host)
+        self._tcl = TclSocketClient(host)
         self._api = IxTclHalApi(self._tcl)
         self.chassis = Chassis(self._api, host)
         self.session = Session(self._api)

--- a/pyixia/tclproto.py
+++ b/pyixia/tclproto.py
@@ -32,6 +32,15 @@ class TclError(Exception):
         return '%s: %s' % (self.__class__.__name__, self.result)
 
 class TclClient:
+    def _tcl_hal_version(self):
+        rsp = self.call('version cget -ixTclHALVersion')
+        return rsp[0].split('.')
+
+    def hal_version(self):
+        """Returns a tuple (major,minor) of the TCL HAL version."""
+        return tuple(self._tcl_hal_version()[0:2])
+
+class TclSocketClient(TclClient):
     def __init__(self, host, port=4555):
         self.host = host
         self.port = port
@@ -70,10 +79,6 @@ class TclClient:
         log.debug('result=%s io_output=%s', result, io_output)
         return result, io_output
 
-    def _tcl_hal_version(self):
-        rsp = self.call('version cget -ixTclHALVersion')
-        return rsp[0].split('.')
-
     def connect(self):
         log.debug('Opening connection to %s:%d', self.host, self.port)
         fd = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -85,7 +90,3 @@ class TclClient:
         log.debug('Closing connection')
         self.fd.close()
         self.fd = None
-
-    def hal_version(self):
-        """Returns a tuple (major,minor) of the TCL HAL version."""
-        return tuple(self._tcl_hal_version()[0:2])


### PR DESCRIPTION
With newer Ixia chassis, there are two different methods to connect to them: plain socket (used for older windows based chassis) and over SSH (used on newer linux based ones).

Prepare the TclClient to support the new method by splitting between functions related to the socket method and common methods.

Signed-off-by: Michael Walle <michael.walle@kontron.com>